### PR TITLE
Added missing states to gpio mux, fixed spi_cs1

### DIFF
--- a/include/gpiomux.h
+++ b/include/gpiomux.h
@@ -27,74 +27,74 @@ static struct gpiomux {
 	char *func[4];
 	unsigned int shift;
 	unsigned int mask;
-} omega2GpioMux[] = 
+} omega2GpioMux[] =
 {
 	{
 		.name = "i2c",
 		.func = { "i2c", "gpio", NULL, NULL },
 		.shift = 20,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "uart0",
 		.func = { "uart", "gpio", NULL, NULL },
 		.shift = 8,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "uart1",
-		.func = { "uart", "gpio", NULL, NULL },
+		.func = { "uart", "gpio", "pwm01", NULL },
 		.shift = 24,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "uart2",
-		.func = { "uart", "gpio", "pwm", NULL },
+		.func = { "uart", "gpio", "pwm23", NULL },
 		.shift = 26,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "pwm0",
 		.func = { "pwm", "gpio", NULL, NULL },
 		.shift = 28,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "pwm1",
 		.func = { "pwm", "gpio", NULL, NULL },
 		.shift = 30,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "refclk",
 		.func = { "refclk", "gpio", NULL, NULL },
 		.shift = 18,
 		.mask = 0x1,
-	}, 
+	},
 	{
 		.name = "spi_s",
-		.func = { "spi_s", "gpio", NULL, NULL },
+		.func = { "spi_s", "gpio", NULL, "pwm01_uart2" },
 		.shift = 2,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "spi_cs1",
-		.func = { "spi_cs1", "gpio", NULL, "refclk" },
+		.func = { "spi_cs1", "gpio", "refclk", NULL },
 		.shift = 4,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "i2s",
 		.func = { "i2s", "gpio", "pcm", NULL },
 		.shift = 6,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "ephy",
 		.func = { "ephy", "gpio", NULL, NULL },
 		.shift = 34,
 		.mask = 0x3,
-	}, 
+	},
 	{
 		.name = "wled",
 		.func = { "wled", "gpio", NULL, NULL },


### PR DESCRIPTION
- spi_s group can also be pwm01+uart2
- uart1 group can also be pwm01
- uart2 group can also be pwm23

- refclk state was wrong for spi_cs1 group